### PR TITLE
Feature/check permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,7 @@
 All notable changes to this project are documented in the GitHub Releases page.
 
 **[Click here to view all releases →](../../releases)**
+
+## Unreleased
+
+- Expose `checkPermissions()` across the Capacitor bridge (iOS, Android, and Web) and document the new API so apps can query AlarmKit readiness from TypeScript.

--- a/README.md
+++ b/README.md
@@ -221,6 +221,8 @@ Result of a permissions request.
 
 Construct a type with a set of properties K of type T
 
-<code>{ [P in K]: T; }</code>
+<code>{
+ [P in K]: T;
+ }</code>
 
 </docgen-api>

--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ npx cap sync
 
 Note: This plugin only exposes native alarm actions (create/open). It does not implement any custom in-app alarm scheduling/CRUD.
 
+## Permission checks
+
+Use `CapgoAlarm.checkPermissions()` to query whether AlarmKit (iOS) or the platform clock integration (Android) is ready before prompting users. The method never opens system UI and returns a `PermissionResult` with `details` describing platform-specific states (for example, `{ alarmKit: true }` on iOS or `{ exactAlarm: false }` on Android 12+).
+
+If your native runtime ships an older build of this plugin that predates the `checkPermissions` bridge, the JavaScript shim resolves with `{ granted: false, message: 'CapgoAlarm.checkPermissions is not implemented...' }` so you can gracefully fall back to feature detection or request an update.
+
 ## API
 
 <docgen-index>
@@ -45,6 +51,7 @@ Note: This plugin only exposes native alarm actions (create/open). It does not i
 * [`openAlarms()`](#openalarms)
 * [`getOSInfo()`](#getosinfo)
 * [`requestPermissions(...)`](#requestpermissions)
+* [`checkPermissions()`](#checkpermissions)
 * [`getPluginVersion()`](#getpluginversion)
 * [Interfaces](#interfaces)
 * [Type Aliases](#type-aliases)
@@ -126,6 +133,22 @@ On Android, may route to settings for exact alarms.
 --------------------
 
 
+### checkPermissions()
+
+```typescript
+checkPermissions() => Promise<PermissionResult>
+```
+
+Check the current permission state for native alarm access without triggering UI.
+On iOS this reports AlarmKit readiness; on Android it reports capability details.
+
+**Returns:** <code>Promise&lt;<a href="#permissionresult">PermissionResult</a>&gt;</code>
+
+**Since:** 8.0.4
+
+--------------------
+
+
 ### getPluginVersion()
 
 ```typescript
@@ -188,6 +211,7 @@ Result of a permissions request.
 | ------------- | ---------------------------------------------------------------- | ---------------------------------- |
 | **`granted`** | <code>boolean</code>                                             | Overall grant for requested scope  |
 | **`details`** | <code><a href="#record">Record</a>&lt;string, boolean&gt;</code> | Optional details by permission key |
+| **`message`** | <code>string</code>                                              | Optional human readable diagnostic |
 
 
 ### Type Aliases

--- a/README.md
+++ b/README.md
@@ -221,8 +221,6 @@ Result of a permissions request.
 
 Construct a type with a set of properties K of type T
 
-<code>{
- [P in K]: T;
- }</code>
+<code>{ [P in K]: T; }</code>
 
 </docgen-api>

--- a/android/src/main/java/app/capgo/capacitor/alarm/CapgoAlarmPlugin.java
+++ b/android/src/main/java/app/capgo/capacitor/alarm/CapgoAlarmPlugin.java
@@ -108,6 +108,27 @@ public class CapgoAlarmPlugin extends Plugin {
     }
 
     @PluginMethod
+    public void checkPermissions(PluginCall call) {
+        JSObject ret = new JSObject();
+        JSObject details = new JSObject();
+        boolean granted = true;
+        boolean hasDetails = false;
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            AlarmManager am = (AlarmManager) getContext().getSystemService(Context.ALARM_SERVICE);
+            boolean canExact = am != null && am.canScheduleExactAlarms();
+            details.put("exactAlarm", canExact);
+            hasDetails = true;
+        }
+
+        ret.put("granted", granted);
+        if (hasDetails) {
+            ret.put("details", details);
+        }
+        call.resolve(ret);
+    }
+
+    @PluginMethod
     public void getPluginVersion(final PluginCall call) {
         try {
             final JSObject ret = new JSObject();

--- a/android/src/main/java/app/capgo/capacitor/alarm/CapgoAlarmPlugin.java
+++ b/android/src/main/java/app/capgo/capacitor/alarm/CapgoAlarmPlugin.java
@@ -113,7 +113,7 @@ public class CapgoAlarmPlugin extends Plugin {
     public void checkPermissions(PluginCall call) {
         JSObject ret = new JSObject();
         JSObject details = new JSObject();
-        boolean granted = true;
+        boolean granted = Build.VERSION.SDK_INT < Build.VERSION_CODES.S;
         boolean hasDetails = false;
         String message = null;
 
@@ -127,6 +127,7 @@ public class CapgoAlarmPlugin extends Plugin {
                 boolean canExact = am != null && am.canScheduleExactAlarms();
                 details.put("exactAlarm", canExact);
                 hasDetails = true;
+                granted = canExact;
                 if (!canExact) {
                     message = "Exact alarm permission not granted";
                 }
@@ -135,6 +136,7 @@ public class CapgoAlarmPlugin extends Plugin {
                 hasDetails = true;
                 message = "Failed to query exact alarm capability";
                 Log.w(TAG, "Unable to determine exact alarm capability status", e);
+                granted = false;
             }
         } else {
             message = "Exact alarm capability check requires Android S+";

--- a/android/src/main/java/app/capgo/capacitor/alarm/CapgoAlarmPlugin.java
+++ b/android/src/main/java/app/capgo/capacitor/alarm/CapgoAlarmPlugin.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.os.Build;
 import android.provider.AlarmClock;
+import android.util.Log;
 import com.getcapacitor.JSObject;
 import com.getcapacitor.Plugin;
 import com.getcapacitor.PluginCall;
@@ -15,6 +16,7 @@ import com.getcapacitor.annotation.CapacitorPlugin;
 public class CapgoAlarmPlugin extends Plugin {
 
     private final String pluginVersion = "8.0.3";
+    private static final String TAG = "CapgoAlarmPlugin";
 
     // ===== Native OS Alarm helpers (Android) =====
     @PluginMethod
@@ -113,17 +115,37 @@ public class CapgoAlarmPlugin extends Plugin {
         JSObject details = new JSObject();
         boolean granted = true;
         boolean hasDetails = false;
+        String message = null;
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-            AlarmManager am = (AlarmManager) getContext().getSystemService(Context.ALARM_SERVICE);
-            boolean canExact = am != null && am.canScheduleExactAlarms();
-            details.put("exactAlarm", canExact);
-            hasDetails = true;
+            try {
+                Context context = getContext();
+                if (context == null) {
+                    throw new IllegalStateException("Plugin context unavailable");
+                }
+                AlarmManager am = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
+                boolean canExact = am != null && am.canScheduleExactAlarms();
+                details.put("exactAlarm", canExact);
+                hasDetails = true;
+                if (!canExact) {
+                    message = "Exact alarm permission not granted";
+                }
+            } catch (Exception e) {
+                details.put("exactAlarm", false);
+                hasDetails = true;
+                message = "Failed to query exact alarm capability";
+                Log.w(TAG, "Unable to determine exact alarm capability status", e);
+            }
+        } else {
+            message = "Exact alarm capability check requires Android S+";
         }
 
         ret.put("granted", granted);
         if (hasDetails) {
             ret.put("details", details);
+        }
+        if (message != null) {
+            ret.put("message", message);
         }
         call.resolve(ret);
     }

--- a/ios/Sources/CapgoAlarmPlugin/AlarmKitBridge.swift
+++ b/ios/Sources/CapgoAlarmPlugin/AlarmKitBridge.swift
@@ -1,181 +1,191 @@
 import Foundation
+
 #if canImport(UIKit)
-import UIKit
+    import UIKit
 #endif
 
 #if canImport(AlarmKit)
-import AlarmKit
-#if canImport(SwiftUI)
-import SwiftUI
-#endif
+    import AlarmKit
+    #if canImport(SwiftUI)
+        import SwiftUI
+    #endif
 
-@available(iOS 26.0, *)
-private struct AlarmBridgeMetadata: AlarmMetadata {
-    let label: String
-}
+    @available(iOS 26.0, *)
+    private struct AlarmBridgeMetadata: AlarmMetadata {
+        let label: String
+    }
 #endif
 
 class AlarmKitBridge {
     static func isAvailable() -> Bool {
         #if canImport(AlarmKit)
-        if #available(iOS 26.0, *) { return true } else { return false }
+            if #available(iOS 26.0, *) { return true } else { return false }
         #else
-        return false
+            return false
         #endif
     }
 
     static func requestAuthorization(completion: @escaping (Bool, String?) -> Void) {
         #if canImport(AlarmKit)
-        if #available(iOS 26.0, *) {
-            Task {
-                do {
-                    let alarmManager = AlarmManager.shared
-                    let state = try await alarmManager.requestAuthorization()
-                    completion(state == .authorized, nil)
-                } catch {
-                    completion(false, "Authorization error: \(error.localizedDescription)")
+            if #available(iOS 26.0, *) {
+                Task {
+                    do {
+                        let alarmManager = AlarmManager.shared
+                        let state = try await alarmManager.requestAuthorization()
+                        completion(state == .authorized, nil)
+                    } catch {
+                        completion(false, "Authorization error: \(error.localizedDescription)")
+                    }
                 }
+                return
             }
-            return
-        }
         #endif
         completion(false, "AlarmKit not available on this device/SDK")
     }
 
     static func currentAuthorizationStatus(completion: @escaping (Bool, String?) -> Void) {
         #if canImport(AlarmKit)
-        if #available(iOS 26.0, *) {
-            Task {
-                do {
-                    let status = try await AlarmManager.shared.requestAuthorization()
-                    completion(status == .authorized, String(describing: status))
-                } catch {
-                    completion(false, "Authorization error: \(error.localizedDescription)")
+            if #available(iOS 26.0, *) {
+                Task {
+                    do {
+                        let status = try await AlarmManager.shared.requestAuthorization()
+                        completion(status == .authorized, String(describing: status))
+                    } catch {
+                        completion(false, "Authorization error: \(error.localizedDescription)")
+                    }
                 }
+                return
             }
-            return
-        }
         #endif
         completion(false, "AlarmKit not available on this device/SDK")
     }
 
-    static func createAlarm(hour: Int, minute: Int, label: String?, completion: @escaping (Bool, String?) -> Void) {
+    static func createAlarm(
+        hour: Int, minute: Int, label: String?, completion: @escaping (Bool, String?) -> Void
+    ) {
         #if canImport(AlarmKit)
-        if #available(iOS 26.0, *) {
-            guard (0..<24).contains(hour), (0..<60).contains(minute) else {
-                completion(false, "Invalid time components for alarm.")
+            if #available(iOS 26.0, *) {
+                guard (0..<24).contains(hour), (0..<60).contains(minute) else {
+                    completion(false, "Invalid time components for alarm.")
+                    return
+                }
+
+                Task {
+                    do {
+                        guard let triggerDate = nextTriggerDate(hour: hour, minute: minute) else {
+                            completion(false, "Unable to compute next trigger date.")
+                            return
+                        }
+                        let displayLabel = sanitizedLabel(label)
+                        let configuration = try alarmConfiguration(
+                            triggerDate: triggerDate, label: displayLabel)
+
+                        _ = try await AlarmManager.shared.schedule(
+                            id: UUID(), configuration: configuration)
+
+                        let formatter = DateFormatter()
+                        formatter.dateStyle = .none
+                        formatter.timeStyle = .short
+                        formatter.locale = Locale.current
+                        formatter.timeZone = Calendar.current.timeZone
+
+                        let message = "Alarm scheduled for \(formatter.string(from: triggerDate))."
+                        completion(true, message)
+                    } catch {
+                        completion(false, "Failed to schedule alarm: \(error.localizedDescription)")
+                    }
+                }
                 return
             }
-
-            Task {
-                do {
-                    guard let triggerDate = nextTriggerDate(hour: hour, minute: minute) else {
-                        completion(false, "Unable to compute next trigger date.")
-                        return
-                    }
-                    let displayLabel = sanitizedLabel(label)
-                    let configuration = try alarmConfiguration(triggerDate: triggerDate, label: displayLabel)
-
-                    _ = try await AlarmManager.shared.schedule(id: UUID(), configuration: configuration)
-
-                    let formatter = DateFormatter()
-                    formatter.dateStyle = .none
-                    formatter.timeStyle = .short
-                    formatter.locale = Locale.current
-                    formatter.timeZone = Calendar.current.timeZone
-
-                    let message = "Alarm scheduled for \(formatter.string(from: triggerDate))."
-                    completion(true, message)
-                } catch {
-                    completion(false, "Failed to schedule alarm: \(error.localizedDescription)")
-                }
-            }
-            return
-        }
         #endif
         completion(false, "AlarmKit not available on this device/SDK")
     }
 
     static func openAlarms(completion: @escaping (Bool, String?) -> Void) {
         #if canImport(UIKit)
-        DispatchQueue.main.async {
-            let candidates = AlarmKitBridge.clockURLCandidates()
-            attemptOpenClock(urls: candidates, index: 0, completion: completion)
-        }
+            DispatchQueue.main.async {
+                let candidates = AlarmKitBridge.clockURLCandidates()
+                attemptOpenClock(urls: candidates, index: 0, completion: completion)
+            }
         #else
-        completion(false, "Clock UI cannot be opened on this platform.")
+            completion(false, "Clock UI cannot be opened on this platform.")
         #endif
     }
 }
 
 #if canImport(AlarmKit)
-@available(iOS 26.0, *)
-private extension AlarmKitBridge {
-    static func sanitizedLabel(_ label: String?) -> String {
-        let trimmed = label?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        return trimmed.isEmpty ? "Alarm" : trimmed
-    }
-
-    static func nextTriggerDate(hour: Int, minute: Int) -> Date? {
-        let now = Date()
-        var components = Calendar.current.dateComponents([.year, .month, .day], from: now)
-        components.hour = hour
-        components.minute = minute
-        components.second = 0
-
-        guard let candidate = Calendar.current.date(from: components) else { return nil }
-        if candidate.timeIntervalSince(now) > 1 {
-            return candidate
+    @available(iOS 26.0, *)
+    extension AlarmKitBridge {
+        fileprivate static func sanitizedLabel(_ label: String?) -> String {
+            let trimmed = label?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            return trimmed.isEmpty ? "Alarm" : trimmed
         }
-        return Calendar.current.date(byAdding: .day, value: 1, to: candidate)
+
+        fileprivate static func nextTriggerDate(hour: Int, minute: Int) -> Date? {
+            let now = Date()
+            var components = Calendar.current.dateComponents([.year, .month, .day], from: now)
+            components.hour = hour
+            components.minute = minute
+            components.second = 0
+
+            guard let candidate = Calendar.current.date(from: components) else { return nil }
+            if candidate.timeIntervalSince(now) > 1 {
+                return candidate
+            }
+            return Calendar.current.date(byAdding: .day, value: 1, to: candidate)
+        }
+
+        fileprivate static func alarmConfiguration(triggerDate: Date, label: String) throws
+            -> AlarmManager.AlarmConfiguration<AlarmBridgeMetadata>
+        {
+            #if canImport(SwiftUI)
+                let stopTitle: LocalizedStringResource = LocalizedStringResource("Stop")
+                let stopButton = AlarmButton(
+                    text: stopTitle, textColor: Color.white, systemImageName: "stop.fill")
+
+                let titleResource = LocalizedStringResource(String.LocalizationValue(label))
+                let alert = AlarmPresentation.Alert(title: titleResource, stopButton: stopButton)
+                let presentation = AlarmPresentation(alert: alert)
+
+                let tintColor = Color.orange
+                let metadata = AlarmBridgeMetadata(label: label)
+
+                let attributes = AlarmAttributes<AlarmBridgeMetadata>(
+                    presentation: presentation, metadata: metadata, tintColor: tintColor)
+                return AlarmManager.AlarmConfiguration<AlarmBridgeMetadata>.alarm(
+                    schedule: .fixed(triggerDate),
+                    attributes: attributes
+                )
+            #else
+                struct MissingSwiftUI: Error {}
+                throw MissingSwiftUI()
+            #endif
+        }
+
     }
-
-    static func alarmConfiguration(triggerDate: Date, label: String) throws -> AlarmManager.AlarmConfiguration<AlarmBridgeMetadata> {
-        #if canImport(SwiftUI)
-        let stopTitle: LocalizedStringResource = LocalizedStringResource("Stop")
-        let stopButton = AlarmButton(text: stopTitle, textColor: Color.white, systemImageName: "stop.fill")
-
-        let titleResource = LocalizedStringResource(String.LocalizationValue(label))
-        let alert = AlarmPresentation.Alert(title: titleResource, stopButton: stopButton)
-        let presentation = AlarmPresentation(alert: alert)
-
-        let tintColor = Color.orange
-        let metadata = AlarmBridgeMetadata(label: label)
-
-        let attributes = AlarmAttributes<AlarmBridgeMetadata>(presentation: presentation, metadata: metadata, tintColor: tintColor)
-        return AlarmManager.AlarmConfiguration<AlarmBridgeMetadata>.alarm(
-            schedule: .fixed(triggerDate),
-            attributes: attributes
-        )
-        #else
-        struct MissingSwiftUI: Error {}
-        throw MissingSwiftUI()
-        #endif
-    }
-
-}
 #endif
 
-
 #if canImport(UIKit)
-private extension AlarmKitBridge {
-    static func clockURLCandidates() -> [URL] {
-        ["clock-alarm://", "clock://", "clock-app://"].compactMap { URL(string: $0) }
-    }
-
-    static func attemptOpenClock(urls: [URL], index: Int, completion: @escaping (Bool, String?) -> Void) {
-        guard index < urls.count else {
-            completion(false, "Clock app not reachable on this device.")
-            return
+    extension AlarmKitBridge {
+        fileprivate static func clockURLCandidates() -> [URL] {
+            ["clock-alarm://", "clock://", "clock-app://"].compactMap { URL(string: $0) }
         }
 
-        UIApplication.shared.open(urls[index], options: [:]) { success in
-            if success {
-                completion(true, nil)
-            } else {
-                attemptOpenClock(urls: urls, index: index + 1, completion: completion)
+        fileprivate static func attemptOpenClock(
+            urls: [URL], index: Int, completion: @escaping (Bool, String?) -> Void
+        ) {
+            guard index < urls.count else {
+                completion(false, "Clock app not reachable on this device.")
+                return
+            }
+
+            UIApplication.shared.open(urls[index], options: [:]) { success in
+                if success {
+                    completion(true, nil)
+                } else {
+                    attemptOpenClock(urls: urls, index: index + 1, completion: completion)
+                }
             }
         }
     }
-}
 #endif

--- a/ios/Sources/CapgoAlarmPlugin/AlarmKitBridge.swift
+++ b/ios/Sources/CapgoAlarmPlugin/AlarmKitBridge.swift
@@ -42,6 +42,23 @@ class AlarmKitBridge {
         completion(false, "AlarmKit not available on this device/SDK")
     }
 
+    static func currentAuthorizationStatus(completion: @escaping (Bool, String?) -> Void) {
+        #if canImport(AlarmKit)
+        if #available(iOS 26.0, *) {
+            Task {
+                do {
+                    let status = try await AlarmManager.shared.requestAuthorization()
+                    completion(status == .authorized, String(describing: status))
+                } catch {
+                    completion(false, "Authorization error: \(error.localizedDescription)")
+                }
+            }
+            return
+        }
+        #endif
+        completion(false, "AlarmKit not available on this device/SDK")
+    }
+
     static func createAlarm(hour: Int, minute: Int, label: String?, completion: @escaping (Bool, String?) -> Void) {
         #if canImport(AlarmKit)
         if #available(iOS 26.0, *) {
@@ -138,6 +155,7 @@ private extension AlarmKitBridge {
 
 }
 #endif
+
 
 #if canImport(UIKit)
 private extension AlarmKitBridge {

--- a/ios/Sources/CapgoAlarmPlugin/AlarmKitBridge.swift
+++ b/ios/Sources/CapgoAlarmPlugin/AlarmKitBridge.swift
@@ -46,14 +46,8 @@ class AlarmKitBridge {
     static func currentAuthorizationStatus(completion: @escaping (Bool, String?) -> Void) {
         #if canImport(AlarmKit)
             if #available(iOS 26.0, *) {
-                Task {
-                    do {
-                        let status = try await AlarmManager.shared.requestAuthorization()
-                        completion(status == .authorized, String(describing: status))
-                    } catch {
-                        completion(false, "Authorization error: \(error.localizedDescription)")
-                    }
-                }
+                let status = AlarmManager.shared.authorizationState
+                completion(status == .authorized, String(describing: status))
                 return
             }
         #endif

--- a/ios/Sources/CapgoAlarmPlugin/CapgoAlarmPlugin.swift
+++ b/ios/Sources/CapgoAlarmPlugin/CapgoAlarmPlugin.swift
@@ -14,6 +14,7 @@ public class CapgoAlarmPlugin: CAPPlugin, CAPBridgedPlugin {
         CAPPluginMethod(name: "createAlarm", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "openAlarms", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "getOSInfo", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "checkPermissions", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "requestPermissions", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "getPluginVersion", returnType: CAPPluginReturnPromise)
     ]
@@ -48,8 +49,15 @@ public class CapgoAlarmPlugin: CAPPlugin, CAPBridgedPlugin {
 
     // Capacitor permission lifecycle
     override public func checkPermissions(_ call: CAPPluginCall) {
-        // No explicit runtime permission needed for AlarmKit; always granted when available
-        call.resolve(["granted": true])
+        let isAlarmKitAvailable = AlarmKitBridge.isAvailable()
+        var result: [String: Any] = [
+            "granted": isAlarmKitAvailable,
+            "details": ["alarmKit": isAlarmKitAvailable]
+        ]
+        if !isAlarmKitAvailable {
+            result["message"] = "AlarmKit not available on this device/SDK"
+        }
+        call.resolve(result)
     }
 
     override public func requestPermissions(_ call: CAPPluginCall) {

--- a/ios/Sources/CapgoAlarmPlugin/CapgoAlarmPlugin.swift
+++ b/ios/Sources/CapgoAlarmPlugin/CapgoAlarmPlugin.swift
@@ -1,10 +1,8 @@
-import Foundation
 import Capacitor
+import Foundation
 
-/**
- * Please read the Capacitor iOS Plugin Development Guide
- * here: https://capacitorjs.com/docs/plugins/ios
- */
+/// Please read the Capacitor iOS Plugin Development Guide
+/// here: https://capacitorjs.com/docs/plugins/ios
 @objc(CapgoAlarmPlugin)
 public class CapgoAlarmPlugin: CAPPlugin, CAPBridgedPlugin {
     private let pluginVersion: String = "8.0.3"
@@ -16,13 +14,16 @@ public class CapgoAlarmPlugin: CAPPlugin, CAPBridgedPlugin {
         CAPPluginMethod(name: "getOSInfo", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "checkPermissions", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "requestPermissions", returnType: CAPPluginReturnPromise),
-        CAPPluginMethod(name: "getPluginVersion", returnType: CAPPluginReturnPromise)
+        CAPPluginMethod(name: "getPluginVersion", returnType: CAPPluginReturnPromise),
     ]
 
     @objc func createAlarm(_ call: CAPPluginCall) {
         let hour = call.getInt("hour") ?? -1
         let minute = call.getInt("minute") ?? -1
-        if hour < 0 || minute < 0 { call.reject("hour and minute are required"); return }
+        if hour < 0 || minute < 0 {
+            call.reject("hour and minute are required")
+            return
+        }
         let label = call.getString("label")
 
         AlarmKitBridge.createAlarm(hour: hour, minute: minute, label: label) { success, message in
@@ -43,7 +44,7 @@ public class CapgoAlarmPlugin: CAPPlugin, CAPBridgedPlugin {
             "platform": "ios",
             "version": version,
             "supportsNativeAlarms": supportsNative,
-            "supportsScheduledNotifications": true
+            "supportsScheduledNotifications": true,
         ])
     }
 
@@ -53,7 +54,7 @@ public class CapgoAlarmPlugin: CAPPlugin, CAPBridgedPlugin {
             call.resolve([
                 "granted": false,
                 "details": ["alarmKit": false],
-                "message": "AlarmKit not available on this device/SDK"
+                "message": "AlarmKit not available on this device/SDK",
             ])
             return
         }
@@ -61,7 +62,7 @@ public class CapgoAlarmPlugin: CAPPlugin, CAPBridgedPlugin {
         AlarmKitBridge.currentAuthorizationStatus { granted, statusDescription in
             var result: [String: Any] = [
                 "granted": granted,
-                "details": ["alarmKit": granted]
+                "details": ["alarmKit": granted],
             ]
             if !granted, let statusDescription = statusDescription {
                 result["message"] = "AlarmKit authorization status: \(statusDescription)"

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -56,6 +56,8 @@ export interface PermissionResult {
   granted: boolean;
   /** Optional details by permission key */
   details?: Record<string, boolean>;
+  /** Optional human readable diagnostic */
+  message?: string;
 }
 
 /**
@@ -139,6 +141,21 @@ export interface CapgoAlarmPlugin {
    * ```
    */
   requestPermissions(options?: { exactAlarm?: boolean }): Promise<PermissionResult>;
+
+  /**
+   * Check the current permission state for native alarm access without triggering UI.
+   * On iOS this reports AlarmKit readiness; on Android it reports capability details.
+   *
+   * @returns Promise that resolves with the permission result
+   * @throws Error if the native layer fails to respond
+   * @since 8.0.4
+   * @example
+   * ```typescript
+   * const status = await CapgoAlarm.checkPermissions();
+   * console.log('AlarmKit allowed?', status.details?.alarmKit);
+   * ```
+   */
+  checkPermissions(): Promise<PermissionResult>;
 
   /**
    * Get the native Capacitor plugin version.

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ const missingCheckPermissionsResult: PermissionResult = {
 
 const nativeCheckPermissions = CapgoAlarm.checkPermissions?.bind(CapgoAlarm);
 
-CapgoAlarm.checkPermissions = (async () => {
+CapgoAlarm.checkPermissions = (async (): Promise<PermissionResult> => {
   if (!nativeCheckPermissions) {
     return missingCheckPermissionsResult;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,44 @@
 import { registerPlugin } from '@capacitor/core';
 
-import type { CapgoAlarmPlugin } from './definitions';
+import type { CapgoAlarmPlugin, PermissionResult } from './definitions';
 
 const CapgoAlarm = registerPlugin<CapgoAlarmPlugin>('CapgoAlarm', {
   web: () => import('./web').then((m) => new m.CapgoAlarmWeb()),
 });
+
+const missingCheckPermissionsResult: PermissionResult = {
+  granted: false,
+  message:
+    'CapgoAlarm.checkPermissions is not implemented on this platform or native plugin version. Update the native plugin to use this feature.',
+};
+
+const nativeCheckPermissions = CapgoAlarm.checkPermissions?.bind(CapgoAlarm);
+
+CapgoAlarm.checkPermissions = (async () => {
+  if (!nativeCheckPermissions) {
+    return missingCheckPermissionsResult;
+  }
+  try {
+    return await nativeCheckPermissions();
+  } catch (error: unknown) {
+    if (isUnimplementedError(error)) {
+      return missingCheckPermissionsResult;
+    }
+    throw error;
+  }
+}) as CapgoAlarmPlugin['checkPermissions'];
+
+function isUnimplementedError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') {
+    return false;
+  }
+  const code = (error as { code?: string }).code;
+  if (code === 'UNIMPLEMENTED') {
+    return true;
+  }
+  const message = (error as { message?: unknown }).message;
+  return typeof message === 'string' && message.toLowerCase().includes('not implemented');
+}
 
 export * from './definitions';
 export { CapgoAlarm };

--- a/src/web.ts
+++ b/src/web.ts
@@ -30,6 +30,13 @@ export class CapgoAlarmWeb extends WebPlugin implements CapgoAlarmPlugin {
     return { granted: true };
   }
 
+  async checkPermissions(): Promise<PermissionResult> {
+    return {
+      granted: false,
+      message: 'Native alarm permissions are not available on web',
+    };
+  }
+
   async getPluginVersion(): Promise<{ version: string }> {
     return { version: 'web' };
   }


### PR DESCRIPTION
## Problem
CapgoAlarm already overrides `checkPermissions` on iOS, but the method was never exposed to JavaScript, and Android didn’t implement it at all. Apps therefore couldn’t determine AlarmKit/AlarmClock readiness or differentiate between “feature unavailable” and “permission denied,” leading to confusing UI flows.

## Solution
- Register `checkPermissions` in the native method tables for both iOS and Android, and implement the Android handler so it reports exact-alarm capability.
- On iOS, return the actual AlarmKit authorization state (authorized/denied/not available) via a new helper in `AlarmKitBridge`, including human-readable diagnostics.
- Extend the TypeScript API with `checkPermissions()` and a `message` field on `PermissionResult`, add a registerPlugin wrapper that yields a friendly fallback when the native layer is outdated, and update the web stub to report that native alarms aren’t available.
- Document the new API (README “Permission checks” section + CHANGELOG) and run `npm run build` to regenerate docgen + bundles.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a cross-platform checkPermissions() API to query current alarm/clock permission state without showing UI; returns a PermissionResult with an optional human-readable message. Available on iOS, Android, and web with graceful fallback when native support is absent.

* **Documentation**
  * Updated README and API docs with usage examples, return type details, fallback/shim behavior, and since-version notes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->