### PR TITLE
feat: add cancelAlarm() method and fix AlarmKit iOS 26.2 compatibility

### DIFF
--- a/.github/scripts/verify-packed-example.sh
+++ b/.github/scripts/verify-packed-example.sh
@@ -40,12 +40,14 @@ bun run build
 
 case "$platform" in
   android)
+    rm -rf android
     bunx cap add android
     bunx cap sync android
     cd android
     ./gradlew build test
     ;;
   ios)
+    rm -rf ios
     bunx cap add ios
     bunx cap sync ios
     xcodebuild -project ios/App/App.xcodeproj -scheme App -destination generic/platform=iOS CODE_SIGNING_ALLOWED=NO

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ If your native runtime ships an older build of this plugin that predates the `ch
 * [`checkPermissions()`](#checkpermissions)
 * [`getPluginVersion()`](#getpluginversion)
 * [`getAlarms()`](#getalarms)
+* [`cancelAlarm(...)`](#cancelalarm)
 * [Interfaces](#interfaces)
 * [Type Aliases](#type-aliases)
 
@@ -189,6 +190,26 @@ as the system does not provide an API to query alarms.
 **Returns:** <code>Promise&lt;{ alarms: AlarmInfo[]; message?: string; }&gt;</code>
 
 **Since:** 1.1.0
+
+--------------------
+
+
+### cancelAlarm(...)
+
+```typescript
+cancelAlarm(options: { id: string; }) => Promise<NativeActionResult>
+```
+
+Cancel a scheduled alarm by its ID.
+On iOS 26+, removes the alarm from AlarmKit. On Android/web, returns not supported.
+
+| Param         | Type                         | Description                                 |
+| ------------- | ---------------------------- | ------------------------------------------- |
+| **`options`** | <code>{ id: string; }</code> | - Options containing the alarm ID to cancel |
+
+**Returns:** <code>Promise&lt;<a href="#nativeactionresult">NativeActionResult</a>&gt;</code>
+
+**Since:** 8.1.0
 
 --------------------
 

--- a/README.md
+++ b/README.md
@@ -221,10 +221,11 @@ On iOS 26+, removes the alarm from AlarmKit. On Android/web, returns not support
 
 Result of a native action.
 
-| Prop          | Type                 | Description                                  |
-| ------------- | -------------------- | -------------------------------------------- |
-| **`success`** | <code>boolean</code> | Whether the action was successful            |
-| **`message`** | <code>string</code>  | Optional message with additional information |
+| Prop          | Type                 | Description                                        |
+| ------------- | -------------------- | -------------------------------------------------- |
+| **`success`** | <code>boolean</code> | Whether the action was successful                  |
+| **`message`** | <code>string</code>  | Optional message with additional information       |
+| **`id`**      | <code>string</code>  | Optional alarm ID (returned by createAlarm on iOS) |
 
 
 #### NativeAlarmCreateOptions

--- a/README.md
+++ b/README.md
@@ -269,13 +269,13 @@ Result of a permissions request.
 
 Information about a scheduled alarm.
 
-| Prop          | Type                 | Description                      |
-| ------------- | -------------------- | -------------------------------- |
-| **`id`**      | <code>string</code>  | Unique identifier for the alarm  |
-| **`hour`**    | <code>number</code>  | Hour of day in 24h format (0-23) |
-| **`minute`**  | <code>number</code>  | Minute of hour (0-59)            |
-| **`label`**   | <code>string</code>  | Optional label for the alarm     |
-| **`enabled`** | <code>boolean</code> | Whether the alarm is enabled     |
+| Prop          | Type                 | Description                                                                             |
+| ------------- | -------------------- | --------------------------------------------------------------------------------------- |
+| **`id`**      | <code>string</code>  | Unique identifier for the alarm                                                         |
+| **`hour`**    | <code>number</code>  | Hour of day in 24h format (0-23). May be absent for alarms created outside this plugin. |
+| **`minute`**  | <code>number</code>  | Minute of hour (0-59). May be absent for alarms created outside this plugin.            |
+| **`label`**   | <code>string</code>  | Optional label for the alarm                                                            |
+| **`enabled`** | <code>boolean</code> | Whether the alarm is enabled                                                            |
 
 
 ### Type Aliases

--- a/android/src/main/java/app/capgo/capacitor/alarm/CapgoAlarmPlugin.java
+++ b/android/src/main/java/app/capgo/capacitor/alarm/CapgoAlarmPlugin.java
@@ -85,7 +85,7 @@ public class CapgoAlarmPlugin extends Plugin {
     }
 
     @Override
-    protected void requestPermissions(PluginCall call) {
+    public void requestPermissions(PluginCall call) {
         boolean requestExact = call.getBoolean("exactAlarm", false);
         JSObject ret = new JSObject();
         if (requestExact && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
@@ -110,7 +110,7 @@ public class CapgoAlarmPlugin extends Plugin {
     }
 
     @Override
-    protected void checkPermissions(PluginCall call) {
+    public void checkPermissions(PluginCall call) {
         JSObject ret = new JSObject();
         JSObject details = new JSObject();
         boolean granted = Build.VERSION.SDK_INT < Build.VERSION_CODES.S;

--- a/android/src/main/java/app/capgo/capacitor/alarm/CapgoAlarmPlugin.java
+++ b/android/src/main/java/app/capgo/capacitor/alarm/CapgoAlarmPlugin.java
@@ -171,4 +171,12 @@ public class CapgoAlarmPlugin extends Plugin {
         ret.put("alarms", new org.json.JSONArray());
         call.resolve(ret);
     }
+
+    @PluginMethod
+    public void cancelAlarm(PluginCall call) {
+        JSObject ret = new JSObject();
+        ret.put("success", false);
+        ret.put("message", "Cancel alarm is not supported on Android");
+        call.resolve(ret);
+    }
 }

--- a/example-app/ios/App/App/Info.plist
+++ b/example-app/ios/App/App/Info.plist
@@ -47,5 +47,7 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<true/>
+	<key>NSAlarmKitUsageDescription</key>
+	<string>This app uses AlarmKit to schedule and manage alarms.</string>
 </dict>
 </plist>

--- a/example-app/ios/App/CapApp-SPM/Package.swift
+++ b/example-app/ios/App/CapApp-SPM/Package.swift
@@ -11,8 +11,8 @@ let package = Package(
             targets: ["CapApp-SPM"])
     ],
     dependencies: [
-        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", from: "8.0.0"),
-        .package(name: "CapgoCapacitorAlarm", path: "../../../node_modules/.bun/@capgo+capacitor-alarm@file+../node_modules/@capgo/capacitor-alarm")
+        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", exact: "8.0.2"),
+        .package(name: "CapgoCapacitorAlarm", path: "../../../..")
     ],
     targets: [
         .target(

--- a/example-app/src/main.js
+++ b/example-app/src/main.js
@@ -117,7 +117,8 @@ return result;
     steps.push(`Created: ${JSON.stringify(createResult, null, 2)}`);
 
     if (!createResult.success || !createResult.id) {
-      steps.push('ERROR: Failed to create alarm or no ID returned');
+      steps.push('ERROR: Failed to create alarm or no ID returned.');
+      steps.push('Tip: Run "Request permissions" first, and ensure iOS 26+ simulator.');
       return steps.join('\n\n');
     }
 

--- a/example-app/src/main.js
+++ b/example-app/src/main.js
@@ -107,8 +107,8 @@ return result;
   ],
   run: async (values) => {
     const steps = [];
-    const hour = Number(values.hour) || 8;
-    const minute = Number(values.minute) || 0;
+    const hour = Number.isNaN(Number(values.hour)) ? 8 : Number(values.hour);
+    const minute = Number.isNaN(Number(values.minute)) ? 0 : Number(values.minute);
     const label = values.label || 'Test Alarm';
 
     // Step 1: Create alarm

--- a/ios/Sources/CapgoAlarmPlugin/AlarmKitBridge.swift
+++ b/ios/Sources/CapgoAlarmPlugin/AlarmKitBridge.swift
@@ -16,6 +16,59 @@ private struct AlarmBridgeMetadata: AlarmMetadata {
 #endif
 
 class AlarmKitBridge {
+    // MARK: - UserDefaults Storage for Alarm Metadata
+
+    private static let storageKey = "CapgoAlarm.alarmMetadata"
+
+    private static func loadStoredMetadata() -> [String: [String: Any]] {
+        UserDefaults.standard.dictionary(forKey: storageKey) as? [String: [String: Any]] ?? [:]
+    }
+
+    private static func saveStoredMetadata(_ metadata: [String: [String: Any]]) {
+        UserDefaults.standard.set(metadata, forKey: storageKey)
+    }
+
+    private static func storeAlarmMetadata(id: String, hour: Int, minute: Int, label: String?) {
+        var metadata = loadStoredMetadata()
+        metadata[id] = [
+            "hour": hour,
+            "minute": minute,
+            "label": label ?? NSNull()
+        ]
+        saveStoredMetadata(metadata)
+    }
+
+    private static func removeAlarmMetadata(id: String) {
+        var metadata = loadStoredMetadata()
+        metadata.removeValue(forKey: id)
+        saveStoredMetadata(metadata)
+    }
+
+    private static func getAlarmMetadata(id: String) -> (hour: Int, minute: Int, label: String?)? {
+        let metadata = loadStoredMetadata()
+        guard let data = metadata[id],
+              let hour = data["hour"] as? Int,
+              let minute = data["minute"] as? Int else {
+            return nil
+        }
+        let label = data["label"] as? String
+        return (hour, minute, label)
+    }
+
+    private static func pruneOrphanedMetadata(validIds: Set<String>) {
+        var metadata = loadStoredMetadata()
+        let storedIds = Set(metadata.keys)
+        let orphanedIds = storedIds.subtracting(validIds)
+        for id in orphanedIds {
+            metadata.removeValue(forKey: id)
+        }
+        if !orphanedIds.isEmpty {
+            saveStoredMetadata(metadata)
+        }
+    }
+
+    // MARK: - Public API
+
     static func isAvailable() -> Bool {
         #if canImport(AlarmKit)
         if #available(iOS 26.0, *) { return true } else { return false }
@@ -53,24 +106,29 @@ class AlarmKitBridge {
         completion(false, "AlarmKit not available on this device/SDK")
     }
 
-    static func createAlarm(hour: Int, minute: Int, label: String?, completion: @escaping (Bool, String?) -> Void) {
+    static func createAlarm(hour: Int, minute: Int, label: String?, completion: @escaping (Bool, String?, String?) -> Void) {
         #if canImport(AlarmKit)
         if #available(iOS 26.0, *) {
             guard (0..<24).contains(hour), (0..<60).contains(minute) else {
-                completion(false, "Invalid time components for alarm.")
+                completion(false, "Invalid time components for alarm.", nil)
                 return
             }
 
             Task {
                 do {
                     guard let triggerDate = nextTriggerDate(hour: hour, minute: minute) else {
-                        completion(false, "Unable to compute next trigger date.")
+                        completion(false, "Unable to compute next trigger date.", nil)
                         return
                     }
                     let displayLabel = sanitizedLabel(label)
                     let configuration = try alarmConfiguration(triggerDate: triggerDate, label: displayLabel)
 
-                    _ = try await AlarmManager.shared.schedule(id: UUID(), configuration: configuration)
+                    // Generate UUID upfront so we can return it and store metadata
+                    let alarmId = UUID()
+                    _ = try await AlarmManager.shared.schedule(id: alarmId, configuration: configuration)
+
+                    // Store metadata for later retrieval
+                    storeAlarmMetadata(id: alarmId.uuidString, hour: hour, minute: minute, label: label)
 
                     let formatter = DateFormatter()
                     formatter.dateStyle = .none
@@ -79,15 +137,15 @@ class AlarmKitBridge {
                     formatter.timeZone = Calendar.current.timeZone
 
                     let message = "Alarm scheduled for \(formatter.string(from: triggerDate))."
-                    completion(true, message)
+                    completion(true, message, alarmId.uuidString)
                 } catch {
-                    completion(false, "Failed to schedule alarm: \(error.localizedDescription)")
+                    completion(false, "Failed to schedule alarm: \(error.localizedDescription)", nil)
                 }
             }
             return
         }
         #endif
-        completion(false, "AlarmKit not available on this device/SDK")
+        completion(false, "AlarmKit not available on this device/SDK", nil)
     }
 
     static func openAlarms(completion: @escaping (Bool, String?) -> Void) {
@@ -108,6 +166,10 @@ class AlarmKitBridge {
                 do {
                     let alarmManager = AlarmManager.shared
                     let alarms = try alarmManager.alarms
+
+                    // Collect valid alarm IDs and prune orphaned metadata
+                    let validIds = Set(alarms.map { $0.id.uuidString })
+                    pruneOrphanedMetadata(validIds: validIds)
 
                     var alarmsList: [[String: Any]] = []
                     for alarm in alarms {
@@ -137,6 +199,8 @@ class AlarmKitBridge {
             }
             do {
                 try AlarmManager.shared.cancel(id: uuid)
+                // Clean up stored metadata
+                removeAlarmMetadata(id: id)
                 completion(true, "Alarm cancelled")
             } catch {
                 completion(false, "Failed to cancel alarm: \(error.localizedDescription)")
@@ -152,13 +216,23 @@ class AlarmKitBridge {
 @available(iOS 26.0, *)
 private extension AlarmKitBridge {
     static func convertAlarmToDict(alarm: Alarm) -> [String: Any]? {
-        // AlarmKit Alarm objects only expose: id, countdownDuration, and state
-        // The schedule/configuration is not accessible after creation
-        // Return available info; hour/minute/label are not retrievable from the Alarm object
+        let idString = alarm.id.uuidString
         let isEnabled = alarm.state == .scheduled || alarm.state == .countdown || alarm.state == .alerting
 
+        // Look up stored metadata for hour/minute/label
+        if let metadata = getAlarmMetadata(id: idString) {
+            return [
+                "id": idString,
+                "hour": metadata.hour,
+                "minute": metadata.minute,
+                "label": metadata.label ?? NSNull(),
+                "enabled": isEnabled
+            ]
+        }
+
+        // Fallback if no stored metadata (alarm created outside this plugin)
         return [
-            "id": alarm.id.uuidString,
+            "id": idString,
             "hour": NSNull(),
             "minute": NSNull(),
             "label": NSNull(),

--- a/ios/Sources/CapgoAlarmPlugin/CapgoAlarmPlugin.swift
+++ b/ios/Sources/CapgoAlarmPlugin/CapgoAlarmPlugin.swift
@@ -27,8 +27,12 @@ public class CapgoAlarmPlugin: CAPPlugin, CAPBridgedPlugin {
         if hour < 0 || minute < 0 { call.reject("hour and minute are required"); return }
         let label = call.getString("label")
 
-        AlarmKitBridge.createAlarm(hour: hour, minute: minute, label: label) { success, message in
-            call.resolve(["success": success, "message": message ?? NSNull()])
+        AlarmKitBridge.createAlarm(hour: hour, minute: minute, label: label) { success, message, alarmId in
+            var result: [String: Any] = ["success": success, "message": message ?? NSNull()]
+            if let alarmId = alarmId {
+                result["id"] = alarmId
+            }
+            call.resolve(result)
         }
     }
 

--- a/ios/Sources/CapgoAlarmPlugin/CapgoAlarmPlugin.swift
+++ b/ios/Sources/CapgoAlarmPlugin/CapgoAlarmPlugin.swift
@@ -17,7 +17,8 @@ public class CapgoAlarmPlugin: CAPPlugin, CAPBridgedPlugin {
         CAPPluginMethod(name: "checkPermissions", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "requestPermissions", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "getPluginVersion", returnType: CAPPluginReturnPromise),
-        CAPPluginMethod(name: "getAlarms", returnType: CAPPluginReturnPromise)
+        CAPPluginMethod(name: "getAlarms", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "cancelAlarm", returnType: CAPPluginReturnPromise)
     ]
 
     @objc func createAlarm(_ call: CAPPluginCall) {
@@ -98,6 +99,16 @@ public class CapgoAlarmPlugin: CAPPlugin, CAPBridgedPlugin {
             } else {
                 call.resolve(["alarms": alarms])
             }
+        }
+    }
+
+    @objc func cancelAlarm(_ call: CAPPluginCall) {
+        guard let id = call.getString("id") else {
+            call.reject("Missing alarm id")
+            return
+        }
+        AlarmKitBridge.cancelAlarm(id: id) { success, message in
+            call.resolve(["success": success, "message": message ?? NSNull()])
         }
     }
 

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -206,4 +206,21 @@ export interface CapgoAlarmPlugin {
    * ```
    */
   getAlarms(): Promise<{ alarms: AlarmInfo[]; message?: string }>;
+
+  /**
+   * Cancel a scheduled alarm by its ID.
+   * On iOS 26+, removes the alarm from AlarmKit. On Android/web, returns not supported.
+   *
+   * @param options - Options containing the alarm ID to cancel
+   * @returns Promise resolving with the result of the action
+   * @since 8.1.0
+   * @example
+   * ```typescript
+   * const result = await CapgoAlarm.cancelAlarm({ id: 'alarm-uuid-here' });
+   * if (result.success) {
+   *   console.log('Alarm cancelled');
+   * }
+   * ```
+   */
+  cancelAlarm(options: { id: string }): Promise<NativeActionResult>;
 }

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -26,6 +26,8 @@ export interface NativeActionResult {
   success: boolean;
   /** Optional message with additional information */
   message?: string;
+  /** Optional alarm ID (returned by createAlarm on iOS) */
+  id?: string;
 }
 
 /**

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -38,10 +38,10 @@ export interface NativeActionResult {
 export interface AlarmInfo {
   /** Unique identifier for the alarm */
   id: string;
-  /** Hour of day in 24h format (0-23) */
-  hour: number;
-  /** Minute of hour (0-59) */
-  minute: number;
+  /** Hour of day in 24h format (0-23). May be absent for alarms created outside this plugin. */
+  hour?: number;
+  /** Minute of hour (0-59). May be absent for alarms created outside this plugin. */
+  minute?: number;
   /** Optional label for the alarm */
   label?: string;
   /** Whether the alarm is enabled */

--- a/src/web.ts
+++ b/src/web.ts
@@ -45,4 +45,8 @@ export class CapgoAlarmWeb extends WebPlugin implements CapgoAlarmPlugin {
   async getAlarms(): Promise<{ alarms: AlarmInfo[] }> {
     return { alarms: [] };
   }
+
+  async cancelAlarm(_options: { id: string }): Promise<NativeActionResult> {
+    return { success: false, message: 'Cancel alarm is not supported on web' };
+  }
 }


### PR DESCRIPTION
## Summary

This PR adds a new `cancelAlarm(id: string)` API method and fixes several issues with AlarmKit compatibility on iOS 26.2 SDK.

### New Features

- **`cancelAlarm({ id: string })`** - Cancel a scheduled alarm by its UUID
  - iOS 26+: Removes alarm from AlarmKit via `AlarmManager.shared.cancel(id:)`
  - Android/Web: Returns `{ success: false, message: "not supported" }`

- **Alarm metadata persistence** - Store hour/minute/label in UserDefaults
  - `createAlarm()` now returns the alarm `id` in the response
  - `getAlarms()` returns full alarm details (hour, minute, label, enabled)
  - Metadata is cleaned up when alarms are cancelled or removed externally

### Bug Fixes

- **iOS 26.2 SDK compatibility** - Fixed breaking API changes in AlarmKit:
  - `Alarm.configuration` no longer exists - now using local UserDefaults storage
  - `Alarm.State.active` -> `.scheduled` / `.countdown` / `.alerting`
  - `AlarmManager.shared.cancel(id:)` is synchronous (removed unnecessary `await`)

- **Android build fix** - Changed `requestPermissions` and `checkPermissions` from `protected` to `public` to match Capacitor 8.x parent class

### CI Fix

- **`verify-packed-example.sh` fix** — The script copies the example-app (which has `ios/` and `android/` directories committed) to a temp directory, then runs `cap add ios/android` which fails with "platform already exists". Added `rm -rf` for the platform directory before `cap add`. **This bug was pre-existing on `main`** — the script was added on May 12 and has never successfully run on any PR (verified by running upstream unmodified `main` code through CI on a [test PR](https://github.com/Ilia/capacitor-alarm/pull/3)).

### Example App Updates

- Added "Cancel alarm" action
- Added "Check permissions" action
- Added "Demo: Metadata persistence" - demonstrates full lifecycle:
  ```
  Create alarm -> Get alarms (with metadata) -> Cancel -> Verify removal
  ```
- Added `NSAlarmKitUsageDescription` to Info.plist (required for AlarmKit)

---

## API Changes

### `NativeActionResult` (updated)
```typescript
interface NativeActionResult {
  success: boolean;
  message?: string;
  id?: string;  // NEW: Returned by createAlarm on iOS
}
```

### `cancelAlarm()` (new)
```typescript
cancelAlarm(options: { id: string }): Promise<NativeActionResult>
```

---

## Files Changed

| File | Changes |
|------|---------|
| `src/definitions.ts` | Add `cancelAlarm` method, add `id` to `NativeActionResult` |
| `src/web.ts` | Add web stub returning "not supported" |
| `ios/.../CapgoAlarmPlugin.swift` | Add bridge method, return alarm ID from createAlarm |
| `ios/.../AlarmKitBridge.swift` | Add UserDefaults storage, fix iOS 26.2 API compatibility |
| `android/.../CapgoAlarmPlugin.java` | Add stub, fix method visibility |
| `example-app/src/main.js` | Add demo actions for new functionality |
| `example-app/.../Info.plist` | Add NSAlarmKitUsageDescription |
| `.github/scripts/verify-packed-example.sh` | Fix pre-existing "platform already exists" CI failure |

---

## Testing

- [x] `npm run fmt` - passed
- [x] `npm run lint` - passed
- [x] `npm run build` - passed
- [x] `npm run verify:ios` - passed
- [x] `npm run verify:android` - passed
- [x] `npm run verify:web` - passed
- [x] Tested on iOS 26+ simulator - full lifecycle works
- [x] Verified CI fix: [test PR](https://github.com/Ilia/capacitor-alarm/pull/3) with unmodified upstream `main` reproduces the same `build_ios`/`build_android` failures

---

## Breaking Changes

None. This is a backwards-compatible addition.

---

Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
